### PR TITLE
Remove compiler specific flag `-j8`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,6 @@ fn build() {
         .cflag("-fPIC")
         .cxxflag("-std=c++11")
         .uses_cxx11()
-        .build_arg("-j8")
         .build();
 
     // set GDCM include path


### PR DESCRIPTION
I am proposing to remove the build argument `-j8` because it does not work on MSVC, and 8 isn't always an ideal number for every machine anyway.

The environment variable `NUM_JOBS` provides a portable alternative if really necessary, but I think this could be decided by the crate consumer. What do you think?
