### PR TITLE
Update snafu and type error definition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cc = "1.0.67"
 
 [dependencies]
 libc = "0.2.88"
-snafu = "0.6.10"
+snafu = "0.7.1"
 strum = "0.20"
 strum_macros = "0.20"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,10 @@ use strum_macros::EnumString;
 use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
-pub enum Error {
+pub struct Error(InnerError);
+
+#[derive(Debug, Snafu)]
+enum InnerError {
     #[snafu(display("GDCM decoding error (status code {})", status))]
     GdcmDecodingError {
         status: u32,
@@ -155,6 +158,6 @@ pub fn decode_single_frame_compressed(
         },
         c => GdcmDecodingSnafu {
             status: c as u32
-        }.fail()
+        }.fail().map_err(Error::from)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,10 @@ use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("GDCM decoding error"))]
-    GdcmDecodingError
+    #[snafu(display("GDCM decoding error (status code {})", status))]
+    GdcmDecodingError {
+        status: u32,
+    }
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -151,6 +153,8 @@ pub fn decode_single_frame_compressed(
             let slice = slice::from_raw_parts_mut(ret.pixel_data as *mut _, ret.size);
             Ok(Box::from_raw(slice))
         },
-        _ => GdcmDecodingError.fail()
+        c => GdcmDecodingSnafu {
+            status: c as u32
+        }.fail()
     }
 }


### PR DESCRIPTION
I felt that this was worth updating in order to bring all dependencies of DICOM-rs to the latest version of SNAFU.

It comes with a small extra of making the error type opaque. Since the intent will mostly be to report the error without inspecting it, this helps make the crate API more stable. However, it can be reverted if you believe that the full definition of the error should be exposed to consumers.