### PR TITLE
Feature gate charls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ name = "gdcm_rs"
 path = "src/lib.rs"
 
 [features]
-disable-charls = []
+charls = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ strum_macros = "0.24.2"
 [lib]
 name = "gdcm_rs"
 path = "src/lib.rs"
+
+[features]
+disable-charls = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ name = "gdcm_rs"
 path = "src/lib.rs"
 
 [features]
+default = ["charls"]
 charls = []

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Rust bindings for [Grassroots DICOM (GDCM)](https://github.com/malaterre/GDCM).
 
 The goal of this project is to provide an easy to use interface with GDCM.
 This can be used to decode a wide variety of compressed DICOM objects.
+### Feature Flags
+* `charls` use built-in libcharls

--- a/build.rs
+++ b/build.rs
@@ -52,7 +52,7 @@ fn build() {
     println!("cargo:rustc-link-lib=static=gdcmMEXD");
     println!("cargo:rustc-link-lib=static=gdcmzlib");
 
-    #[cfg(not(feature="disable-charls"))]
+    #[cfg(feature="charls")]
     println!("cargo:rustc-link-lib=static=gdcmcharls");
 
     // FIXME: OSX ONLY

--- a/build.rs
+++ b/build.rs
@@ -39,7 +39,6 @@ fn build() {
 
     // gdcm libs
     println!("cargo:rustc-link-lib=static=gdcmMSFF");
-    println!("cargo:rustc-link-lib=static=gdcmcharls");
     println!("cargo:rustc-link-lib=static=gdcmCommon");
     println!("cargo:rustc-link-lib=static=gdcmDICT");
     println!("cargo:rustc-link-lib=static=gdcmDSED");
@@ -52,6 +51,9 @@ fn build() {
     println!("cargo:rustc-link-lib=static=gdcmuuid");
     println!("cargo:rustc-link-lib=static=gdcmMEXD");
     println!("cargo:rustc-link-lib=static=gdcmzlib");
+
+    #[cfg(not(feature="disable-charls"))]
+    println!("cargo:rustc-link-lib=static=gdcmcharls");
 
     // FIXME: OSX ONLY
     println!("Building for {}", env::consts::OS);


### PR DESCRIPTION
This feature gates the linking of gdcmcharls as it conflicts when trying to link libcharls on the project (this is useful when using libcharls to encode jpeg-ls). 