### PR TITLE
Add GDCM licenses to license metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/pevers/gdcm-rs"
 repository = "https://github.com/pevers/gdcm-rs"
 readme = "README.md"
 keywords = ["dicom", "gdcm", "pixel", "encoding"]
-license = "MIT"
+license = "MIT AND BSD-2-Clause AND BSD-3-Clause AND Apache-2.0 AND OFFIS"
 authors = ["Peter Evers <pevers90@gmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -7,5 +7,7 @@ Rust bindings for [Grassroots DICOM (GDCM)](https://github.com/malaterre/GDCM).
 
 The goal of this project is to provide an easy to use interface with GDCM.
 This can be used to decode a wide variety of compressed DICOM objects.
+
 ### Feature Flags
+
 * `charls` use built-in libcharls

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ pub enum GDCMTransferSyntax {
     RLELossless,
     #[strum(serialize = "1.2.840.10008.1.2.4.100")]
     MPEG2MainProfile,
-    ImplicitVRBigEndianACRNEMA, // Unkown
+    ImplicitVRBigEndianACRNEMA, // Unknown
     WeirdPapryus,               // Unknown
     CT_private_ELE,             // Unknown
     #[strum(serialize = "1.2.840.10008.1.2.4.95")]


### PR DESCRIPTION
See https://github.com/malaterre/GDCM/pull/182 for more details